### PR TITLE
UI tweaks

### DIFF
--- a/src/devtools/client/debugger/src/components/Editor/Editor.css
+++ b/src/devtools/client/debugger/src/components/Editor/Editor.css
@@ -88,6 +88,10 @@ html[dir="rtl"] .editor-mount {
   line-height: var(--theme-code-line-height);
 }
 
+.jsdebugger .CodeMirror {
+  background-color: var(--theme-body-background);
+}
+
 /* set the linenumber white when there is a breakpoint */
 .editor-wrapper:not(.skip-pausing)
   .new-breakpoint

--- a/src/devtools/client/debugger/src/components/shared/menu.css
+++ b/src/devtools/client/debugger/src/components/shared/menu.css
@@ -2,41 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-/* menupopup {
-  position: fixed;
-  z-index: 10000;
-  background: white;
-  border: 1px solid #cccccc;
-  padding: 5px 0;
-  background: #f2f2f2;
-  border-radius: 5px;
-  color: #585858;
-  box-shadow: 0 0 4px 0 rgba(190, 190, 190, 0.8);
-  min-width: 130px;
-} */
-
-menuitem {
-  display: block;
-  padding: 0 20px;
-  line-height: 20px;
-  font-weight: 500;
-  font-size: 13px;
-  user-select: none;
-}
-
-menuitem:hover {
-  background: #3780fb;
-  color: white;
-}
-
-menuitem[disabled="true"] {
-  color: #cccccc;
-}
-
-menuitem[disabled="true"]:hover {
-  background-color: transparent;
-  cursor: default;
-}
 
 /* menuseparator {
   border-bottom: 1px solid #cacdd3;
@@ -53,4 +18,45 @@ menuitem[disabled="true"]:hover {
   width: 100%;
   height: 100%;
   z-index: 999;
+}
+
+
+.context-menu {
+  background: #f2f2f2;
+  box-shadow: 0 0 4px 0 rgba(190, 190, 190, 0.8);
+  border: solid 1px gray;
+  z-index: 100;
+  border-radius: 5px;
+  color: #585858;
+  padding: 5px 0;
+  border: 1px solid #cccccc;
+}
+
+.context-menu-item {
+  font-size: small;
+  padding: 1px 10px 1px 10px;
+  cursor: default;
+}
+
+.context-menu-item:first-child {
+  margin-top: 4px;
+}
+
+.context-menu-item:last-child {
+  margin-bottom: 4px;
+}
+
+.context-menu-item.disabled {
+  color: lightgray;
+}
+
+.context-menu-item:not(.disabled):hover {
+  background-color: #0a84ff;
+  color: white;
+}
+
+.context-menu-separator {
+  height: 1px;
+  background-color: #b7b7b7a8;
+  margin: 3px 0px;
 }

--- a/src/devtools/client/framework/menu.js
+++ b/src/devtools/client/framework/menu.js
@@ -36,14 +36,14 @@ function Menu({ id = null } = {}) {
  *
  * @param {MenuItem} menuItem
  */
-Menu.prototype.append = function(menuItem) {
+Menu.prototype.append = function (menuItem) {
   this.menuitems.push(menuItem);
 };
 
 /**
  * Remove all items from the Menu
  */
-Menu.prototype.clear = function() {
+Menu.prototype.clear = function () {
   this.menuitems = [];
 };
 
@@ -53,7 +53,7 @@ Menu.prototype.clear = function() {
  * @param {int} pos
  * @param {MenuItem} menuItem
  */
-Menu.prototype.insert = function(pos, menuItem) {
+Menu.prototype.insert = function (pos, menuItem) {
   throw Error("Not implemented");
 };
 
@@ -65,7 +65,7 @@ Menu.prototype.insert = function(pos, menuItem) {
  * @param {Document} doc
  *        The document that should own the popup.
  */
-Menu.prototype.popupAtTarget = function(target, doc) {
+Menu.prototype.popupAtTarget = function (target, doc) {
   const zoom = getCurrentZoom(doc);
 
   const rect = target.getBoundingClientRect();
@@ -89,7 +89,7 @@ let gMenuPopup;
  * @param {int} screenX
  * @param {int} screenY
  */
-Menu.prototype.popup = function(screenX, screenY) {
+Menu.prototype.popup = function (screenX, screenY) {
   // The context-menu will be created in the topmost window to preserve keyboard
   // navigation (see Bug 1543940).
   // Keep a reference on the window owning the menu to hide the popup on unload.
@@ -113,6 +113,7 @@ Menu.prototype.popup = function(screenX, screenY) {
 
   // Remove the menu from the DOM once it's hidden.
   popup.addEventListener("popuphidden", e => {
+
     if (e.target === popup) {
       win.removeEventListener("unload", onWindowUnload);
       popup.remove();
@@ -129,7 +130,7 @@ Menu.prototype.popup = function(screenX, screenY) {
   if (gMenuPopup) {
     try {
       document.body.removeChild(gMenuPopup);
-    } catch (e) {}
+    } catch (e) { }
   }
   gMenuPopup = popup;
 
@@ -143,6 +144,7 @@ Menu.prototype.popup = function(screenX, screenY) {
   popup.style.left = `${left}px`;
 
   const listener = () => {
+    return
     gMenuPopup = null;
     document.body.removeChild(popup);
     document.removeEventListener("mousedown", listener);
@@ -153,7 +155,7 @@ Menu.prototype.popup = function(screenX, screenY) {
   document.body.addEventListener("contextmenu", listener);
 };
 
-Menu.prototype._createMenuItems = function(parent) {
+Menu.prototype._createMenuItems = function (parent) {
   const doc = parent.ownerDocument;
   this.menuitems.forEach(item => {
     if (!item.visible) {
@@ -188,7 +190,7 @@ Menu.prototype._createMenuItems = function(parent) {
   });
 };
 
-Menu.getMenuElementById = function(id, doc) {
+Menu.getMenuElementById = function (id, doc) {
   const menuDoc = DevToolsUtils.getTopWindow(doc.defaultView).document;
   return menuDoc.getElementById(id);
 };

--- a/src/devtools/client/shared/sourceeditor/codemirror/lib/codemirror.css
+++ b/src/devtools/client/shared/sourceeditor/codemirror/lib/codemirror.css
@@ -3,7 +3,7 @@
 .CodeMirror {
   /* Set height, width, borders, and global font properties here */
   font-family: monospace;
-  height: 300px;
+  /* height: 300px; */
   color: black;
   direction: ltr;
 }

--- a/src/devtools/client/themes/webconsole.css
+++ b/src/devtools/client/themes/webconsole.css
@@ -319,6 +319,10 @@
   text-align: end;
 }
 
+.message-location a {
+  color: var(--frame-link-source);
+}
+
 .webconsole-app .message-location:empty {
   display: none;
 }
@@ -438,6 +442,7 @@ html #webconsole-notificationbox {
   background-image: url(data:image/svg+xml;base64,PCEtLSBUaGlzIFNvdXJjZSBDb2RlIEZvcm0gaXMgc3ViamVjdCB0byB0aGUgdGVybXMgb2YgdGhlIE1vemlsbGEgUHVibGljCiAgIC0gTGljZW5zZSwgdi4gMi4wLiBJZiBhIGNvcHkgb2YgdGhlIE1QTCB3YXMgbm90IGRpc3RyaWJ1dGVkIHdpdGggdGhpcwogICAtIGZpbGUsIFlvdSBjYW4gb2J0YWluIG9uZSBhdCBodHRwOi8vbW96aWxsYS5vcmcvTVBMLzIuMC8uIC0tPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDEyIDEyIiB3aWR0aD0iMTIiIGhlaWdodD0iMTIiPgogIDxwYXRoIGZpbGw9ImNvbnRleHQtZmlsbCIgZD0iTTEuMDcgMS4zMmMuMy0uMy43Ny0uMyAxLjA2IDBsNC4xNSA0LjE1YS43NS43NSAwIDAgMSAwIDEuMDZsLTQuMTUgNC4xNWEuNzUuNzUgMCAxIDEtMS4wNi0xLjA2TDQuNjkgNiAxLjA3IDIuMzhhLjc1Ljc1IDAgMCAxIDAtMS4wNnptNSAwYy4zLS4zLjc3LS4zIDEuMDYgMGw0LjE1IDQuMTVhLjc1Ljc1IDAgMCAxIDAgMS4wNmwtNC4xNSA0LjE1YS43NS43NSAwIDEgMS0xLjA2LTEuMDZMOS42OSA2IDYuMDcgMi4zOGEuNzUuNzUgMCAwIDEgMC0xLjA2eiIvPgo8L3N2Zz4K);
   background-position-x: calc(10px + var(--console-icon-horizontal-offset));
   background-position-y: 4px;
+  background-color: var(--theme-sidebar-background);
   background-repeat: no-repeat;
   background-size: 12px 12px;
   -moz-context-properties: fill;
@@ -537,8 +542,9 @@ a.learn-more-link.webconsole-learn-more-link {
   | 🗑 - Filter Input | Error - Warning - Log - Info - Debug - CSS - Network - XHR | ✕ |
   --------------------------------------------------------------------------------------
 */
+/* NOTE: the firefox implementation relies on subgrid, which is not implemented in chrome */
 .webconsole-filteringbar-wrapper {
-  display: grid;
+  display: flex;
   grid-template-columns: 1fr auto;
   --primary-toolbar-height: 29px;
 }
@@ -554,6 +560,7 @@ a.learn-more-link.webconsole-learn-more-link {
   flex: 100 0 -moz-fit-content;
   align-items: center;
   min-height: var(--primary-toolbar-height);
+  flex-grow: 1;
 }
 
 .devtools-toolbar.webconsole-filterbar-secondary {

--- a/src/devtools/client/webconsole/components/App.css
+++ b/src/devtools/client/webconsole/components/App.css
@@ -91,10 +91,12 @@ body {
 .flexible-output-input {
   position: relative;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .flexible-output-input .webconsole-output {
-  height: calc(100% - 55px);
+  /* height: calc(100% - 55px); */
   overflow: hidden auto;
 }
 
@@ -142,7 +144,8 @@ body {
   padding-bottom: var(--jsterm-padding-bottom);
   border-top-color: var(--theme-splitter-color);
   border-top-width: var(--jsterm-border-width);
-  border-top-style: solid;
+  border-top-style: solid; 
+  flex-grow: 100;
 }
 
 .webconsole-app .webconsole-output:not(:empty) ~ .jsterm-input-container {

--- a/src/devtools/client/webconsole/store.js
+++ b/src/devtools/client/webconsole/store.js
@@ -49,7 +49,7 @@ function configureStore(webConsoleUI, options = {}) {
   //options.logLimit || Math.max(getIntPref("devtools.hud.loglimit"), 1);
   const sidebarToggle = false; // getBoolPref(PREFS.FEATURES.SIDEBAR_TOGGLE);
   const autocomplete = true; // getBoolPref(PREFS.FEATURES.AUTOCOMPLETE);
-  const eagerEvaluation = true; // getBoolPref(PREFS.FEATURES.EAGER_EVALUATION);
+  const eagerEvaluation = false; // getBoolPref(PREFS.FEATURES.EAGER_EVALUATION);
   const groupWarnings = false; // getBoolPref(PREFS.FEATURES.GROUP_WARNINGS);
   const historyCount = 300; // getIntPref(PREFS.UI.INPUT_HISTORY_COUNT);
 

--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,7 @@ async function initialize() {
 
   initSocket(dispatch);
 
-  paintMessage("Loading…");
+  paintMessage("");
 
   sendMessage("Recording.getDescription", { recordingId }).then(
     (description) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -166,46 +166,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   height: 100%;
 }
 
-.context-menu {
-  background: var(--theme-toolbar-background);
-  box-shadow: 3px 3px 5px gray;
-  border: solid 1px gray;
-  border-radius: 5px;
-  z-index: 100;
-}
-
-.context-menu-item {
-  font-size: small;
-  padding: 1px 10px 1px 10px;
-  cursor: default;
-}
-
-.context-menu-item:first-child {
-  margin-top: 4px;
-}
-
-.context-menu-item:last-child {
-  margin-bottom: 4px;
-}
-
-.context-menu-item.disabled {
-  color: lightgray;
-}
-
-.context-menu-item:not(.disabled):hover {
-  background-color: #0a84ff;
-  color: white;
-}
-
-.context-menu-separator {
-  height: 1px;
-  background-color: gray;
-  margin: 3px 0px;
-}
-
 .webconsole-app {
   height: 100%;
-  background-color: white;
+  background-color: var(--theme-body-background);
 }
 
 @import url("devtools/client/themes/toolbox.css");

--- a/src/ui/components/Toolbox.js
+++ b/src/ui/components/Toolbox.js
@@ -44,18 +44,18 @@ export default class Toolbox extends React.Component {
             <div id="toolbox-border"></div>
             <div id="toolbox-timeline"></div>
             <div id="toolbox-toolbar">
-                <div className="toolbar-panel-button" id="toolbox-toolbar-jsdebugger">
-                    <div className="toolbar-panel-icon"></div>
-          Debugger
-        </div>
-                <div className="toolbar-panel-button" id="toolbox-toolbar-webconsole">
-                    <div className="toolbar-panel-icon"></div>
-          Console
-        </div>
                 <div className="toolbar-panel-button" id="toolbox-toolbar-inspector">
                     <div className="toolbar-panel-icon"></div>
-          Inspector
-        </div>
+                    Inspector
+                </div>
+                <div className="toolbar-panel-button" id="toolbox-toolbar-jsdebugger">
+                    <div className="toolbar-panel-icon"></div>
+                    Debugger
+                </div>
+                <div className="toolbar-panel-button" id="toolbox-toolbar-webconsole">
+                    <div className="toolbar-panel-icon"></div>
+                    Console
+                </div>
             </div>
             <div id="toolbox-contents">
                 <div className="toolbar-panel-content" id="toolbox-content-jsdebugger"></div>


### PR DESCRIPTION
A smorgasbord of changes

- console input fills the remaining height, which is what chrome does and is simpler
- the console filter bar layout is better
- dark mode has a bunch of changes
- context menus look better
- removed "Loading..." from graphics. This should be snappy enough not to be needed. If we do want a loading ui, we can do that with a better visual.
- moved inspector to the left. 


<img width="1284" alt="Screen Shot 2020-05-31 at 9 48 44 PM" src="https://user-images.githubusercontent.com/254562/83376853-9510b000-a388-11ea-9e80-5e8173141aa6.png"> 


<img width="1283" alt="Screen Shot 2020-05-31 at 9 48 33 PM" src="https://user-images.githubusercontent.com/254562/83376851-92ae5600-a388-11ea-9c75-6da4d404a1a3.png">
