### PR TITLE
Add viewer store

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<html class="theme-light">
+<html>
   <meta charset="utf-8" />
 
   <body>

--- a/src/devtools/client/debugger/src/utils/bootstrap.js
+++ b/src/devtools/client/debugger/src/utils/bootstrap.js
@@ -10,7 +10,7 @@ import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 
 import ToolboxProvider from "devtools/client/framework/store-provider";
-import { isFirefoxPanel, isDevelopment, isTesting } from "devtools-environment";
+import { isDevelopment } from "devtools-environment";
 import { AppConstants } from "devtools-modules";
 
 import * as search from "../workers/search";
@@ -62,10 +62,9 @@ export function bootstrapStore(
   panel: Panel,
   initialState: Object
 ) {
-  const debugJsModules = false; // AppConstants.AppConstants.DEBUG_JS_MODULES == "1";
   const createStore = configureStore({
-    log: prefs.logging || isTesting(),
-    timing: debugJsModules || isDevelopment(),
+    log: prefs.logging,
+    timing: prefs.timing,
     makeThunkArgs: (args, state) => {
       return { ...args, client, ...workers, panel };
     },

--- a/src/devtools/client/debugger/src/utils/prefs.js
+++ b/src/devtools/client/debugger/src/utils/prefs.js
@@ -16,6 +16,7 @@ const { pref } = Services;
 // Debugger prefs.
 pref("devtools.browsertoolbox.fission", false);
 pref("devtools.debugger.logging", false);
+pref("devtools.debugger.timing", false);
 pref("devtools.debugger.alphabetize-outline", false);
 pref("devtools.debugger.auto-pretty-print", false);
 pref("devtools.source-map.client-service.enabled", true);
@@ -110,6 +111,7 @@ pref("devtools.defaultColorUnit", "authored");
 export const prefs = new PrefsHelper("devtools", {
   fission: ["Bool", "browsertoolbox.fission"],
   logging: ["Bool", "debugger.logging"],
+  timing: ["Bool", "debugger.timing"],
   editorWrapping: ["Bool", "debugger.ui.editor-wrapping"],
   alphabetizeOutline: ["Bool", "debugger.alphabetize-outline"],
   autoPrettyPrint: ["Bool", "debugger.auto-pretty-print"],

--- a/src/main.js
+++ b/src/main.js
@@ -45,15 +45,13 @@ if (test) {
 
 require("./styles.css");
 
-const React = require("react");
-const ReactDOM = require("react-dom");
-const App = require("ui/components/App").default;
-
 const { initSocket, sendMessage, log } = require("protocol/socket");
 const { ThreadFront } = require("protocol/thread");
 const { paintMessage } = require("protocol/graphics");
 const { throttle, clamp, EventEmitter } = require("protocol/utils");
 const loadImages = require("image/image");
+
+import { bootstrapApp } from "ui/utils/bootstrap";
 
 window.PrefObserver = function () {};
 window.PrefObserver.prototype = {
@@ -111,8 +109,5 @@ setTimeout(async () => {
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
-  ReactDOM.render(
-    React.createElement(App, { initialize }),
-    document.querySelector("#viewer")
-  );
+  bootstrapApp({ initialize });
 }, 0);

--- a/src/ui/actions/app.js
+++ b/src/ui/actions/app.js
@@ -1,0 +1,3 @@
+export function updateTheme(theme) {
+  return { type: "update_theme", theme };
+}

--- a/src/ui/actions/index.js
+++ b/src/ui/actions/index.js
@@ -1,0 +1,3 @@
+import * as appActions from "./app";
+
+export const actions = { ...appActions };

--- a/src/ui/components/App.js
+++ b/src/ui/components/App.js
@@ -34,15 +34,29 @@ const React = require("react");
 const ReactDOM = require("react-dom");
 import Toolbox from "./Toolbox";
 import SplitBox from "devtools/client/shared/components/splitter/SplitBox";
+import { connect } from "react-redux";
+import { actions } from "../actions";
+import { selectors } from "../reducers";
 
-export default class App extends React.Component {
+function setTheme(theme) {
+  document.body.parentElement.className = theme;
+}
+
+class App extends React.Component {
   state = {
     orientation: "bottom",
   };
 
   componentDidMount() {
-    // for testing `app.setState({orientation: "left"})`
-    window.app = this;
+    const { theme } = this.props;
+    setTheme(theme);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { theme } = this.props;
+    if (theme !== prevProps.theme) {
+      setTheme(theme);
+    }
   }
 
   render() {
@@ -90,3 +104,12 @@ export default class App extends React.Component {
     );
   }
 }
+
+export default connect(
+  state => ({
+    theme: selectors.getTheme(state),
+  }),
+  {
+    updateTheme: actions.updateTheme,
+  }
+)(App);

--- a/src/ui/reducers/app.js
+++ b/src/ui/reducers/app.js
@@ -1,0 +1,20 @@
+function initialAppState() {
+  return {
+    theme: "theme-light",
+  };
+}
+
+export default function update(state = initialAppState(), action) {
+  switch (action.type) {
+    case "update_theme": {
+      return { ...state, theme: action.theme };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export function getTheme(state) {
+  return state.app.theme;
+}

--- a/src/ui/reducers/index.js
+++ b/src/ui/reducers/index.js
@@ -1,0 +1,7 @@
+import app, * as appSelectors from "./app";
+
+export const reducers = {
+  app,
+};
+
+export const selectors = { ...appSelectors };

--- a/src/ui/utils/bootstrap.js
+++ b/src/ui/utils/bootstrap.js
@@ -1,0 +1,49 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { Provider } from "react-redux";
+
+import { prefs } from "devtools/client/debugger/src/utils/prefs";
+import configureStore from "devtools/client/debugger/src/actions/utils/create-store";
+import { bindActionCreators, combineReducers } from "redux";
+import { reducers, selectors } from "../reducers";
+import { actions } from "../actions";
+import App from "ui/components/App";
+
+const initialState = {};
+
+function bindSelectors(obj) {
+  return Object.keys(obj.selectors).reduce((bound, selector) => {
+    bound[selector] = (a, b, c) =>
+      obj.selectors[selector](obj.store.getState(), a, b, c);
+    return bound;
+  }, {});
+}
+
+function bootstrapStore() {
+  const createStore = configureStore({
+    log: prefs.logging,
+    timing: prefs.timing,
+    makeThunkArgs: (args, state) => {
+      return { ...args };
+    },
+  });
+
+  const store = createStore(combineReducers(reducers), initialState);
+
+  window.app = {
+    store,
+    actions: bindActionCreators(actions, store.dispatch),
+    selectors: bindSelectors({ store, selectors }),
+  };
+
+  return store;
+}
+
+export function bootstrapApp(props) {
+  const store = bootstrapStore();
+
+  ReactDOM.render(
+    React.createElement(Provider, { store }, React.createElement(App, props)),
+    document.querySelector("#viewer")
+  );
+}


### PR DESCRIPTION
Adds a top level redux store. Eventually the other panels will likely hook into this store as well.

Adds theme management to the store. 

moves some app bootstrap logic into `bootstrap`,