### PR TITLE
Fix open-inspector button

### DIFF
--- a/src/image/image.js
+++ b/src/image/image.js
@@ -115,6 +115,7 @@ const gMaskImages = {
   ".tree-node button.arrow": require("devtools/client/debugger/images/arrow.svg"),
   "#header .logo": require("./images/logo.svg"),
   "#command-button-pick::before": require("devtools/client/themes/images/command-pick.svg"),
+  "button.open-inspector": require("devtools/client/themes/images/open-inspector.svg"),
 };
 
 const gContentImages = {


### PR DESCRIPTION
it irked me that we were showing a black box previously


<img width="687" alt="Screen Shot 2020-06-22 at 5 19 16 PM" src="https://user-images.githubusercontent.com/254562/85347143-97a88600-b4ac-11ea-95f5-0e05d63697fc.png">
