### PR TITLE
Removing line height css that causes the close button to overflow

### DIFF
--- a/src/devtools/client/debugger/src/components/SecondaryPanes/Expressions.css
+++ b/src/devtools/client/debugger/src/components/SecondaryPanes/Expressions.css
@@ -89,8 +89,6 @@
 
 .expression-container .tree .tree-node[aria-level="1"] {
   padding-top: 0px;
-  /* keep line-height at 14px to prevent row from shifting upon expansion */
-  line-height: 14px;
 }
 
 .expression-container .tree-node[aria-level="1"] .object-label {


### PR DESCRIPTION
Checked to see that the row does not shift upon expansion